### PR TITLE
Use https for API endpoints and documentation links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,3 @@
-.. image:: https://travis-ci.org/ndanielsen/py-votesmart.svg?branch=develop
-    :target: https://travis-ci.org/ndanielsen/py-votesmart
-.. image:: https://coveralls.io/repos/github/ndanielsen/py-votesmart/badge.svg?branch=develop
-    :target: https://coveralls.io/github/ndanielsen/py-votesmart?branch=develop
 
 ================
 py-votesmart
@@ -11,7 +7,7 @@ Python 3 supported library for interacting with the Project Vote Smart API.
 
 The Project Vote Smart API provides detailed information on politicians,
 including bios, votes, and NPAT responses.
-(http://votesmart.org/services_api.php)
+(https://votesmart.org/share/api)
 
 All code is under a BSD-style license, see LICENSE for details.
 
@@ -23,11 +19,11 @@ Originally written by James Turk <jturk@sunlightfoundation.com>.
 
 Original Source: https://github.com/votesmart/python-votesmart
 
+Python 3 fork: https://github.com/ndanielsen/py-votesmart
+
 Installation
 ============
-py-votesmart is compatible with Python 2.7 or later, but it is preferred to use Python 3.5 or later to take full advantage of all functionality. The simplest way to install py-votesmart is from PyPI with pip, Python’s preferred package installer.
-
-    >>> pip install py-votesmart
+py-votesmart is compatible with Python 2.7 or later, but it is preferred to use Python 3.5 or later to take full advantage of all functionality.
 
 Usage
 =====
@@ -35,7 +31,7 @@ Usage
 To initialize the api, all that is required is for it to be imported and for an
 API key to be defined.
 
-(If you do not have an API key visit http://votesmart.org/services_api.php to
+(If you do not have an API key visit https://votesmart.org/share/api to
 register for one.)
 
 Import ``votesmart`` from ``VoteSmartAPI``:
@@ -46,5 +42,3 @@ And set your API key:
 
     >>> vsmart = VoteSmartAPI(api_key="VOTE_SMART_API_KEY")
 
-
-More documented use to come.

--- a/votesmart/api.py
+++ b/votesmart/api.py
@@ -15,7 +15,7 @@ class VoteSmartAPI:
         self.api_key = api_key
 
     def api_call(self, function, params):
-        request_str = "http://api.votesmart.org/{function}".format(function=function)
+        request_str = "https://api.votesmart.org/{function}".format(function=function)
         payload = self._set_payload(params)
         response = requests.get(request_str, params=payload)
         try:

--- a/votesmart/methods/address.py
+++ b/votesmart/methods/address.py
@@ -1,7 +1,7 @@
 """
 Address methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Address.html
+https://api.votesmart.org/docs/Address.html
 """
 
 

--- a/votesmart/methods/candidatebio.py
+++ b/votesmart/methods/candidatebio.py
@@ -1,7 +1,7 @@
 """
 CandidateBio methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/CandidateBio.html
+https://api.votesmart.org/docs/CandidateBio.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/candidates.py
+++ b/votesmart/methods/candidates.py
@@ -1,7 +1,7 @@
 """
 Candidates methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Candidates.html
+https://api.votesmart.org/docs/Candidates.html
 """
 
 

--- a/votesmart/methods/committee.py
+++ b/votesmart/methods/committee.py
@@ -1,7 +1,7 @@
 """
 Committee methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Committee.html
+https://api.votesmart.org/docs/Committee.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/district.py
+++ b/votesmart/methods/district.py
@@ -1,7 +1,7 @@
 """
 District methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/District.html
+https://api.votesmart.org/docs/District.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/elections.py
+++ b/votesmart/methods/elections.py
@@ -1,7 +1,7 @@
 """
 Election methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Election.html
+https://api.votesmart.org/docs/Election.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/leadership.py
+++ b/votesmart/methods/leadership.py
@@ -1,7 +1,7 @@
 """
 Leadership methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Leadership.html
+https://api.votesmart.org/docs/Leadership.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/local.py
+++ b/votesmart/methods/local.py
@@ -1,7 +1,7 @@
 """
 Local methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Local.html
+https://api.votesmart.org/docs/Local.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/measure.py
+++ b/votesmart/methods/measure.py
@@ -1,7 +1,7 @@
 """
 Measure methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Measure.html
+https://api.votesmart.org/docs/Measure.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/npat.py
+++ b/votesmart/methods/npat.py
@@ -5,7 +5,7 @@ Political Courage Test
 
 Returns a candidates most recently filled out Political Courage Test.
 
-http://api.votesmart.org/docs/Npat.html
+https://api.votesmart.org/docs/Npat.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/office.py
+++ b/votesmart/methods/office.py
@@ -1,7 +1,7 @@
 """
 Office methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Office.html
+https://api.votesmart.org/docs/Office.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/officials.py
+++ b/votesmart/methods/officials.py
@@ -1,7 +1,7 @@
 """
 Officials methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Officials.html
+https://api.votesmart.org/docs/Officials.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/ratings.py
+++ b/votesmart/methods/ratings.py
@@ -1,7 +1,7 @@
 """
 Rating methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Rating.html
+https://api.votesmart.org/docs/Rating.html
 """
 
 from .base import APIMethodBase

--- a/votesmart/methods/states.py
+++ b/votesmart/methods/states.py
@@ -1,7 +1,7 @@
 """
 State methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/State.html
+https://api.votesmart.org/docs/State.html
 """
 
 

--- a/votesmart/methods/votes.py
+++ b/votesmart/methods/votes.py
@@ -1,7 +1,7 @@
 """
 Votes methods that correspond to this API documentation page
 
-http://api.votesmart.org/docs/Votes.html
+https://api.votesmart.org/docs/Votes.html
 """
 
 


### PR DESCRIPTION
As of April 2022, Project Vote Smart's servers no longer respond to insecure http API requests and only serve documentation over https. This PR updates the endpoint and API docs links accordingly, plus minor cleanup to the top-level README.