### PR TITLE
Version bump to 0.4.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 py-votesmart changelog
 ==========================
 
+0.4.5
+-----
+    * NationalJournal fork of ndanielsen/py-votesmart
+    * Require requests>=2.20.0 (was ==2.20.0)
+    * Use https for API endpoints and documentation links
+
 0.4.4
 -----
     * Add Local, Leadership, Npat, Measure and Office API methods

--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,12 @@ def get_requires(path=REQUIRE_PATH):
             yield line
 
 setup(name="py-votesmart",
-      version="0.4.4",
+      version="0.4.5",
       description="Libraries for interacting with the Project Vote Smart API",
       author="Nathan Danielsen <nathan.danielsen@gmail.com>",
       author_email = "nathan.danielsen@gmail.com",
       license="BSD",
-      url="http://github.com/ndanielsen/py-votesmart/",
+      url="https://github.com/NationalJournal/py-votesmart/",
       long_description="py-votesmart is a fork of the original python-votesmart with python3 support",
       packages=find_packages(where=PROJECT, exclude=EXCLUDES),
 


### PR DESCRIPTION
Set a new minor version number to distinguish our changes since forking from the parent repo (https://github.com/ndanielsen/py-votesmart):
- #1
- #2