### PR TITLE
Distinguish data-not-found 404s from malformed-URL 404s

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 py-votesmart changelog
 ==========================
 
+2.0.6
+-----
+    * Discriminate "no data" 404s from malformed-URL 404s by inspecting the
+      response body. The "no data" body shape
+      (``{"message": "Not Found", "statusCode": 404}``) now raises a new
+      ``VotesmartNotFoundError`` exception (a subclass of
+      ``VotesmartApiError``); list-shaped endpoints that flow through
+      ``paginated_api_call`` catch it and return an empty list. Express's
+      "Cannot GET /v1/..." body and any other unrecognized 404 still raise
+      the broad ``VotesmartApiError``. Callers previously string-matching
+      ``"No candidates found"`` should switch to ``except VotesmartNotFoundError``.
+
 0.4.5
 -----
     * NationalJournal fork of ndanielsen/py-votesmart

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_requires(path=REQUIRE_PATH):
 
 setup(
     name="py-votesmart",
-    version="2.0.5",
+    version="2.0.6",
     description="Python library for the Vote Smart REST API 2.0",
     author="Nathan Danielsen <nathan.danielsen@gmail.com>",
     author_email="nathan.danielsen@gmail.com",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ import requests
 import pytest
 
 from votesmart.api import VoteSmartAPI
-from votesmart.exceptions import VotesmartApiError
+from votesmart.exceptions import VotesmartApiError, VotesmartNotFoundError
 
 
 def _make_jwt(exp=None):
@@ -137,13 +137,20 @@ def test_api_call_retries_on_401(mocker):
     assert response == {'data': []}
 
 
-def test_api_call_raises_on_404(mocker):
-    """404 should raise VotesmartApiError."""
+def test_api_call_raises_endpoint_not_found_on_malformed_url_404(mocker):
+    """404 with Express's "Cannot GET" body shape signals a wrong URL — a
+    caller bug. Always raises the broad VotesmartApiError (not the subclass)
+    so the data-not-found path stays distinguishable."""
     token = _make_jwt()
     mocker.patch.object(requests, 'post')
 
     not_found = mock.Mock()
     not_found.status_code = 404
+    not_found.json.return_value = {
+        "message": "Cannot GET /v1/nonexistent",
+        "error": "Not Found",
+        "statusCode": 404,
+    }
     mocker.patch.object(requests, 'get', return_value=not_found)
 
     api = VoteSmartAPI(
@@ -151,8 +158,57 @@ def test_api_call_raises_on_404(mocker):
         password="password",
         access_token=token,
     )
-    with pytest.raises(VotesmartApiError):
+    with pytest.raises(VotesmartApiError) as exc_info:
         api.api_call('v1/nonexistent')
+    # Should be the broad type, not the data-not-found subclass.
+    assert not isinstance(exc_info.value, VotesmartNotFoundError)
+    assert "Endpoint not found" in str(exc_info.value)
+
+
+def test_api_call_raises_not_found_subclass_on_data_not_found_404(mocker):
+    """404 with the "no data" body shape signals the route is valid but VS
+    has nothing for this query (e.g. a General stage before the Primary has
+    happened). Raises VotesmartNotFoundError so list-shaped callers can
+    catch and treat as empty."""
+    token = _make_jwt()
+    mocker.patch.object(requests, 'post')
+
+    not_found = mock.Mock()
+    not_found.status_code = 404
+    not_found.json.return_value = {"message": "Not Found", "statusCode": 404}
+    mocker.patch.object(requests, 'get', return_value=not_found)
+
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=token,
+    )
+    with pytest.raises(VotesmartNotFoundError) as exc_info:
+        api.api_call('v1/elections/5342/stage-candidates', {'stageId': 'G'})
+    assert "Resource not found" in str(exc_info.value)
+
+
+def test_api_call_raises_endpoint_not_found_on_unparseable_404_body(mocker):
+    """If the 404 body isn't JSON (HTML error page from a load balancer,
+    empty body, etc.) treat it as an unknown error and raise the broad
+    type. Only the explicit "no data" body shape opts in to the typed
+    subclass — anything else stays visible."""
+    token = _make_jwt()
+    mocker.patch.object(requests, 'post')
+
+    not_found = mock.Mock()
+    not_found.status_code = 404
+    not_found.json.side_effect = ValueError("No JSON")
+    mocker.patch.object(requests, 'get', return_value=not_found)
+
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=token,
+    )
+    with pytest.raises(VotesmartApiError) as exc_info:
+        api.api_call('v1/something')
+    assert not isinstance(exc_info.value, VotesmartNotFoundError)
 
 
 def test_api_call_raises_on_500_with_json(mocker):

--- a/tests/test_methods/test_base.py
+++ b/tests/test_methods/test_base.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+from votesmart.exceptions import VotesmartNotFoundError
 from votesmart.methods.containers import VotesmartApiObject
 from votesmart.methods.base import APIMethodBase
 
@@ -30,3 +33,37 @@ def test_result_to_obj_empty_list():
     obj = APIMethodBase(api_instance="fake instance")
     result = obj.result_to_obj(VotesmartApiObject, [])
     assert result == []
+
+
+def test_paginated_api_call_returns_empty_on_not_found():
+    """List-shaped endpoints surface VS's "no data" 404 as an empty list,
+    so the caller can iterate normally without an exception. Common case:
+    /stage-candidates for a stage VS doesn't have candidates for yet."""
+    fake_api = mock.Mock()
+    fake_api.api_call.side_effect = VotesmartNotFoundError(
+        "Resource not found: v1/elections/5342/stage-candidates (HTTP 404)"
+    )
+    obj = APIMethodBase(api_instance=fake_api)
+    result = obj.paginated_api_call(
+        'v1/elections/5342/stage-candidates', {'stageId': 'G'}
+    )
+    assert result == []
+    fake_api.api_call.assert_called_once()
+
+
+def test_paginated_api_call_stops_paginating_on_not_found_mid_stream():
+    """If a subsequent page comes back as 404 (unusual but possible), stop
+    paginating and return whatever was collected up to that point."""
+    page_one = {
+        'data': [{'id': 1}],
+        'meta': {'currentPage': 1, 'lastPage': 2, 'perPage': 1000},
+    }
+    fake_api = mock.Mock()
+    fake_api.api_call.side_effect = [
+        page_one,
+        VotesmartNotFoundError("Resource not found (HTTP 404)"),
+    ]
+    obj = APIMethodBase(api_instance=fake_api)
+    result = obj.paginated_api_call('v1/something')
+    assert result == [{'id': 1}]
+    assert fake_api.api_call.call_count == 2

--- a/votesmart/__init__.py
+++ b/votesmart/__init__.py
@@ -1,3 +1,4 @@
 from .api import VoteSmartAPI
+from .exceptions import VotesmartApiError, VotesmartNotFoundError
 
-__all__ = ["VoteSmartAPI"]
+__all__ = ["VoteSmartAPI", "VotesmartApiError", "VotesmartNotFoundError"]

--- a/votesmart/api.py
+++ b/votesmart/api.py
@@ -5,7 +5,7 @@ import time
 import requests
 
 from .methods.utils import parse_api_response
-from .exceptions import VotesmartApiError
+from .exceptions import VotesmartApiError, VotesmartNotFoundError
 from . import methods
 
 
@@ -150,6 +150,26 @@ class VoteSmartAPI:
             response = requests.get(url, params=params or {}, headers=headers)
 
         if response.status_code == 404:
+            try:
+                body = response.json()
+            except ValueError:
+                body = None
+            # Route exists but VS has no data for this query. Body shape:
+            #   {"message": "Not Found", "statusCode": 404}
+            # List-shaped callers (paginated_api_call) catch this and return []
+            # so iteration can proceed; object-shaped callers let it propagate
+            # so they can tell when they passed a bad ID.
+            if (
+                isinstance(body, dict)
+                and body.get("message") == "Not Found"
+                and "error" not in body
+            ):
+                raise VotesmartNotFoundError(
+                    "Resource not found: {} (HTTP 404)".format(url)
+                )
+            # Anything else — Express's "Cannot GET /v1/..." for a wrong path,
+            # an HTML page from infrastructure, an empty body, an unexpected
+            # shape — is a caller bug or upstream issue. Surface it.
             raise VotesmartApiError(
                 "Endpoint not found: {} (HTTP 404)".format(url)
             )

--- a/votesmart/exceptions.py
+++ b/votesmart/exceptions.py
@@ -1,2 +1,13 @@
 class VotesmartApiError(Exception):
-    """Exception for Votesmart API errors """
+    """Exception for Votesmart API errors"""
+
+
+class VotesmartNotFoundError(VotesmartApiError):
+    """Raised when the API returns a 404 with the "no data" body shape:
+    ``{"message": "Not Found", "statusCode": 404}``.
+
+    Distinguished from a malformed-URL 404 (Express's default no-route
+    handler, which returns ``{"message": "Cannot GET /v1/...", ...}``) so
+    list-shaped endpoints can return an empty list while object-shaped
+    endpoints still surface a missing resource to the caller.
+    """

--- a/votesmart/methods/base.py
+++ b/votesmart/methods/base.py
@@ -1,6 +1,8 @@
 """Command functions instances for API Calls
 """
 
+from ..exceptions import VotesmartNotFoundError
+
 
 class APIMethodBase:
     def __init__(self, api_instance):
@@ -29,7 +31,14 @@ class APIMethodBase:
         all_data = []
 
         while True:
-            result = self.api.api_call(endpoint, params)
+            try:
+                result = self.api.api_call(endpoint, params)
+            except VotesmartNotFoundError:
+                # VS returns 404 ("no data" body shape) when a list-shaped
+                # endpoint genuinely has nothing to return — most commonly
+                # /stage-candidates for a stage that hasn't happened yet.
+                # Treat as an empty list and stop paginating.
+                break
             data = result.get('data', [])
             if isinstance(data, list):
                 all_data.extend(data)


### PR DESCRIPTION
# Ticket 8534 (nj-cms)

### Context
Follow-up to NJ-CMS #8534. Vote Smart's REST API 2.0 returns 404 for two distinct conditions, and the wrapper has been treating both the same way — leading to ~240 Sentry events / 48 hours from `update_racetracker_election_data` since the 2.0 wrapper went live.

Bruno-confirmed body shapes:

| Condition | Example | Response body |
|---|---|---|
| Malformed URL (wrong path) | `GET /v1/election/99999999` (typo: singular `election`) | `{"message": "Cannot GET /v1/election/99999999", "error": "Not Found", "statusCode": 404}` |
| Route valid, no data | `GET /v1/elections/5342/stage-candidates?stageId=G&stateId=UT` (General stage of a 2026 race; Primary hasn't happened yet) | `{"message": "Not Found", "statusCode": 404}` |

### Solution
- New `VotesmartNotFoundError(VotesmartApiError)` for the data-not-found case 22aa574
- `api_call` discriminates by body: known data-not-found shape → typed subclass; everything else (Express 404, HTML page, unparseable body, empty body) → broad `VotesmartApiError` 22aa574
- `paginated_api_call` catches `VotesmartNotFoundError` and returns `[]` so list-shaped endpoints surface "no data" as an empty list rather than an exception 22aa574
- Object-shaped methods (`getElection(id)`, `getCandidate(id)`) don't catch — callers can tell when they passed a bad ID 22aa574
- `VotesmartNotFoundError` exported from `votesmart/__init__.py` so callers can `from votesmart import VotesmartNotFoundError` 22aa574

### Caller migration (separate PR in nj-cms)
After this releases as 2.0.6, the nj-cms caller in `racetracker/utils/votesmart_utils.py` can drop its string-match guard (`if "No candidates found" not in str(e)`) — the wrapper now handles it. That cleanup will land separately.

### Testing
- [ ] `python -m pytest tests/ --ignore=tests/test_live_api.py` — 157 tests pass locally
- [ ] New unit tests cover all four 404 paths:
  - Malformed-URL body → `VotesmartApiError` (NOT the subclass)
  - Data-not-found body → `VotesmartNotFoundError`
  - Unparseable body → broad `VotesmartApiError` (conservative default)
  - Paginated call wrapping a `VotesmartNotFoundError` → `[]`
- [ ] Mid-stream pagination case (page 1 succeeds, page 2 is 404) → returns page 1's data, no exception
- [ ] **Post-merge in `nj-cms`:** bump `requirements.txt` to `py-votesmart==2.0.6`, re-run `update_racetracker_election_data --states UT --year 2026`, confirm Sentry "Endpoint not found" event volume drops to near-zero.

### Version bump
`setup.py`: 2.0.5 → 2.0.6. CHANGELOG entry added (note: the changelog has been silent since 0.4.5 — I added a 2.0.6 heading at the top; happy to drop if the team is officially done with it).