### PR TITLE
8558 Rate limiting and retry with backoff

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,39 @@
 py-votesmart changelog
 ==========================
 
+2.1.0
+-----
+    * Rate-limiting / retry overhaul. ``api_call`` now transparently
+      retries on transient HTTP errors (429, 502, 503, 504), honoring
+      the server's ``Retry-After`` header when present and falling back
+      to exponential backoff with multiplicative jitter otherwise.
+      Configurable via constructor params: ``max_retries`` (default 5),
+      ``retry_initial_backoff`` (1.0s), ``retry_max_backoff`` (60.0s),
+      ``retry_backoff_jitter`` (±50%), ``retry_after_max`` (300.0s cap).
+    * New typed exception subclasses of ``VotesmartApiError``:
+
+        * ``VotesmartRateLimitError`` — raised on 429 after retries
+          exhausted. Catch this if you want to back off further at the
+          application layer.
+        * ``VotesmartServerError`` — raised on 5xx after retries
+          exhausted. Indicates a Vote Smart upstream problem.
+        * ``VotesmartClientError`` — raised on 4xx other than 404/429
+          (400/401-after-refresh/403/etc). Caller-side problem;
+          retrying won't help.
+
+      All ``VotesmartApiError`` instances (and subclasses) now carry
+      ``status_code`` and ``response_body`` attributes for introspection,
+      and their string form includes ``(HTTP <code>)`` automatically.
+      Existing ``except VotesmartApiError`` catches still work — the
+      new types subclass it.
+    * New ``rate_limiter`` constructor param: pluggable callable
+      ``f() -> None`` that blocks until the next request is allowed.
+      Use this to plug in a distributed limiter (e.g. Redis-backed
+      token bucket) shared across processes. Takes precedence over
+      the existing in-process ``rate_limit=N`` (req/sec) limiter,
+      which still works for the single-process case.
+    * No new external dependencies.
+
 2.0.6
 -----
     * Discriminate "no data" 404s from malformed-URL 404s by inspecting the

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_requires(path=REQUIRE_PATH):
 
 setup(
     name="py-votesmart",
-    version="2.0.6",
+    version="2.1.0",
     description="Python library for the Vote Smart REST API 2.0",
     author="Nathan Danielsen <nathan.danielsen@gmail.com>",
     author_email="nathan.danielsen@gmail.com",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,13 +1,21 @@
+import base64
+import email.utils
 import json
 import time
-import base64
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
-import requests
 import pytest
+import requests
 
 from votesmart.api import VoteSmartAPI
-from votesmart.exceptions import VotesmartApiError, VotesmartNotFoundError
+from votesmart.exceptions import (
+    VotesmartApiError,
+    VotesmartClientError,
+    VotesmartNotFoundError,
+    VotesmartRateLimitError,
+    VotesmartServerError,
+)
 
 
 def _make_jwt(exp=None):
@@ -23,6 +31,41 @@ def _make_jwt(exp=None):
     return '{}.{}.{}'.format(
         header.decode(), payload.decode(), sig.decode()
     )
+
+
+def _mock_response(status_code, json_data=None, headers=None, text=None):
+    """Build a Mock that mimics a requests.Response for our assertions."""
+    resp = mock.Mock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    if json_data is not None:
+        resp.json.return_value = json_data
+    else:
+        resp.json.side_effect = ValueError("No JSON")
+    resp.text = text if text is not None else ""
+    return resp
+
+
+@pytest.fixture
+def fast_retries(mocker):
+    """Patch time.sleep in the api module so retry loops don't really wait."""
+    return mocker.patch("votesmart.api.time.sleep")
+
+
+@pytest.fixture
+def authed_api(mocker):
+    """An API instance with a valid cached JWT, no real auth call made."""
+    mocker.patch.object(requests, "post")
+    return VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=_make_jwt(),
+    )
+
+
+# ---------------------------------------------------------------------
+# Smoke / init
+# ---------------------------------------------------------------------
 
 
 def test_sanity():
@@ -41,7 +84,7 @@ def test_init_api_no_password():
 
 def test_init_with_valid_cached_token(mocker):
     """If a valid token is supplied, no auth call should be made."""
-    mocker.patch.object(requests, 'post')
+    mocker.patch.object(requests, "post")
     token = _make_jwt()
     api = VoteSmartAPI(
         email="test@test.com",
@@ -58,10 +101,8 @@ def test_init_with_expired_token_triggers_auth(mocker):
     expired_token = _make_jwt(exp=int(time.time()) - 100)
     new_token = _make_jwt()
 
-    auth_response = mock.Mock()
-    auth_response.status_code = 200
-    auth_response.json.return_value = {"accessToken": new_token}
-    mocker.patch.object(requests, 'post', return_value=auth_response)
+    auth_response = _mock_response(200, {"accessToken": new_token})
+    mocker.patch.object(requests, "post", return_value=auth_response)
 
     api = VoteSmartAPI(
         email="test@test.com",
@@ -76,38 +117,36 @@ def test_init_with_expired_token_triggers_auth(mocker):
 def test_init_without_token_triggers_auth(mocker):
     """No token at all should trigger authentication."""
     new_token = _make_jwt()
-    auth_response = mock.Mock()
-    auth_response.status_code = 200
-    auth_response.json.return_value = {"accessToken": new_token}
-    mocker.patch.object(requests, 'post', return_value=auth_response)
+    auth_response = _mock_response(200, {"accessToken": new_token})
+    mocker.patch.object(requests, "post", return_value=auth_response)
 
     api = VoteSmartAPI(email="test@test.com", password="password")
     requests.post.assert_called_once()
     assert api.access_token == new_token
 
 
-def test_api_call(mocker):
+# ---------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------
+
+
+def test_api_call(mocker, authed_api):
     """api_call should make a GET with Bearer auth header."""
-    token = _make_jwt()
-    mocker.patch.object(requests, 'post')
+    response = _mock_response(200, {"data": [{"id": 1}]})
+    mocker.patch.object(requests, "get", return_value=response)
 
-    json_mock = mock.Mock()
-    json_mock.status_code = 200
-    json_mock.json.return_value = {'data': [{'id': 1}]}
-    mocker.patch.object(requests, 'get', return_value=json_mock)
-
-    api = VoteSmartAPI(
-        email="test@test.com",
-        password="password",
-        access_token=token,
-    )
-    response = api.api_call('v1/elections/by-year-state', {'year': 2024})
+    result = authed_api.api_call("v1/elections/by-year-state", {"year": 2024})
 
     requests.get.assert_called_once()
     call_args = requests.get.call_args
-    assert 'v1/elections/by-year-state' in call_args[0][0]
-    assert 'Bearer' in call_args[1]['headers']['Authorization']
-    assert response == {'data': [{'id': 1}]}
+    assert "v1/elections/by-year-state" in call_args[0][0]
+    assert "Bearer" in call_args[1]["headers"]["Authorization"]
+    assert result == {"data": [{"id": 1}]}
+
+
+# ---------------------------------------------------------------------
+# 401 re-auth (regression — existing behavior preserved)
+# ---------------------------------------------------------------------
 
 
 def test_api_call_retries_on_401(mocker):
@@ -115,149 +154,485 @@ def test_api_call_retries_on_401(mocker):
     token = _make_jwt()
     new_token = _make_jwt(exp=int(time.time()) + 90000)
 
-    auth_response = mock.Mock()
-    auth_response.status_code = 200
-    auth_response.json.return_value = {"accessToken": new_token}
-    mocker.patch.object(requests, 'post', return_value=auth_response)
+    auth_response = _mock_response(200, {"accessToken": new_token})
+    mocker.patch.object(requests, "post", return_value=auth_response)
 
-    unauthorized = mock.Mock()
-    unauthorized.status_code = 401
-    success = mock.Mock()
-    success.status_code = 200
-    success.json.return_value = {'data': []}
-    mocker.patch.object(requests, 'get', side_effect=[unauthorized, success])
+    unauthorized = _mock_response(401)
+    success = _mock_response(200, {"data": []})
+    mocker.patch.object(requests, "get", side_effect=[unauthorized, success])
 
     api = VoteSmartAPI(
         email="test@test.com",
         password="password",
         access_token=token,
     )
-    response = api.api_call('v1/states')
+    result = api.api_call("v1/states")
     assert requests.get.call_count == 2
-    assert response == {'data': []}
+    assert result == {"data": []}
 
 
-def test_api_call_raises_endpoint_not_found_on_malformed_url_404(mocker):
+# ---------------------------------------------------------------------
+# 404 discrimination (regression)
+# ---------------------------------------------------------------------
+
+
+def test_api_call_raises_endpoint_not_found_on_malformed_url_404(
+    mocker, authed_api
+):
     """404 with Express's "Cannot GET" body shape signals a wrong URL — a
     caller bug. Always raises the broad VotesmartApiError (not the subclass)
     so the data-not-found path stays distinguishable."""
-    token = _make_jwt()
-    mocker.patch.object(requests, 'post')
-
-    not_found = mock.Mock()
-    not_found.status_code = 404
-    not_found.json.return_value = {
-        "message": "Cannot GET /v1/nonexistent",
-        "error": "Not Found",
-        "statusCode": 404,
-    }
-    mocker.patch.object(requests, 'get', return_value=not_found)
-
-    api = VoteSmartAPI(
-        email="test@test.com",
-        password="password",
-        access_token=token,
+    not_found = _mock_response(
+        404,
+        {
+            "message": "Cannot GET /v1/nonexistent",
+            "error": "Not Found",
+            "statusCode": 404,
+        },
     )
+    mocker.patch.object(requests, "get", return_value=not_found)
+
     with pytest.raises(VotesmartApiError) as exc_info:
-        api.api_call('v1/nonexistent')
-    # Should be the broad type, not the data-not-found subclass.
+        authed_api.api_call("v1/nonexistent")
     assert not isinstance(exc_info.value, VotesmartNotFoundError)
     assert "Endpoint not found" in str(exc_info.value)
+    assert exc_info.value.status_code == 404
 
 
-def test_api_call_raises_not_found_subclass_on_data_not_found_404(mocker):
+def test_api_call_raises_not_found_subclass_on_data_not_found_404(
+    mocker, authed_api
+):
     """404 with the "no data" body shape signals the route is valid but VS
-    has nothing for this query (e.g. a General stage before the Primary has
-    happened). Raises VotesmartNotFoundError so list-shaped callers can
-    catch and treat as empty."""
-    token = _make_jwt()
-    mocker.patch.object(requests, 'post')
+    has nothing for this query. Raises VotesmartNotFoundError so list-shaped
+    callers can catch and treat as empty."""
+    not_found = _mock_response(404, {"message": "Not Found", "statusCode": 404})
+    mocker.patch.object(requests, "get", return_value=not_found)
 
-    not_found = mock.Mock()
-    not_found.status_code = 404
-    not_found.json.return_value = {"message": "Not Found", "statusCode": 404}
-    mocker.patch.object(requests, 'get', return_value=not_found)
-
-    api = VoteSmartAPI(
-        email="test@test.com",
-        password="password",
-        access_token=token,
-    )
     with pytest.raises(VotesmartNotFoundError) as exc_info:
-        api.api_call('v1/elections/5342/stage-candidates', {'stageId': 'G'})
+        authed_api.api_call(
+            "v1/elections/5342/stage-candidates", {"stageId": "G"}
+        )
     assert "Resource not found" in str(exc_info.value)
+    assert exc_info.value.status_code == 404
 
 
-def test_api_call_raises_endpoint_not_found_on_unparseable_404_body(mocker):
+def test_api_call_raises_endpoint_not_found_on_unparseable_404_body(
+    mocker, authed_api
+):
     """If the 404 body isn't JSON (HTML error page from a load balancer,
-    empty body, etc.) treat it as an unknown error and raise the broad
-    type. Only the explicit "no data" body shape opts in to the typed
-    subclass — anything else stays visible."""
-    token = _make_jwt()
-    mocker.patch.object(requests, 'post')
+    empty body, etc.) treat it as an unknown error and raise the broad type."""
+    not_found = _mock_response(404)
+    mocker.patch.object(requests, "get", return_value=not_found)
 
-    not_found = mock.Mock()
-    not_found.status_code = 404
-    not_found.json.side_effect = ValueError("No JSON")
-    mocker.patch.object(requests, 'get', return_value=not_found)
-
-    api = VoteSmartAPI(
-        email="test@test.com",
-        password="password",
-        access_token=token,
-    )
     with pytest.raises(VotesmartApiError) as exc_info:
-        api.api_call('v1/something')
+        authed_api.api_call("v1/something")
     assert not isinstance(exc_info.value, VotesmartNotFoundError)
 
 
-def test_api_call_raises_on_500_with_json(mocker):
-    """500 with JSON body should raise via parse_api_response."""
-    token = _make_jwt()
-    mocker.patch.object(requests, 'post')
+# ---------------------------------------------------------------------
+# Retry-on-transient (the new behavior)
+# ---------------------------------------------------------------------
 
-    error_response = mock.Mock()
-    error_response.status_code = 500
-    error_response.json.return_value = {
-        "statusCode": 500, "message": "Internal Server Error"
-    }
-    mocker.patch.object(requests, 'get', return_value=error_response)
+
+def test_429_retried_with_eventual_success(mocker, fast_retries, authed_api):
+    """A 429 followed by a 200 should succeed transparently to the caller."""
+    rate_limited = _mock_response(
+        429, {"statusCode": 429, "message": "Too Many Requests"}
+    )
+    success = _mock_response(200, {"data": [{"id": 1}]})
+    mocker.patch.object(requests, "get", side_effect=[rate_limited, success])
+
+    result = authed_api.api_call("v1/candidatebios/123/detail")
+    assert result == {"data": [{"id": 1}]}
+    assert requests.get.call_count == 2
+    assert fast_retries.call_count == 1
+
+
+def test_503_retried_with_eventual_success(mocker, fast_retries, authed_api):
+    """5xx codes (502, 503, 504) are also retried."""
+    server_err = _mock_response(503, text="Service Unavailable")
+    success = _mock_response(200, {"ok": True})
+    mocker.patch.object(requests, "get", side_effect=[server_err, success])
+
+    result = authed_api.api_call("v1/states")
+    assert result == {"ok": True}
+
+
+def test_429_retried_until_max_then_raises_rate_limit_error(
+    mocker, fast_retries
+):
+    """When retries are exhausted on 429, raise VotesmartRateLimitError."""
+    mocker.patch.object(requests, "post")
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=_make_jwt(),
+        max_retries=2,
+    )
+    rate_limited = _mock_response(
+        429, {"statusCode": 429, "message": "Too Many Requests"}
+    )
+    mocker.patch.object(requests, "get", return_value=rate_limited)
+
+    with pytest.raises(VotesmartRateLimitError) as exc_info:
+        api.api_call("v1/candidatebios/123/detail")
+    assert exc_info.value.status_code == 429
+    assert "Too Many Requests" in str(exc_info.value)
+    # max_retries=2 means 3 total attempts (initial + 2 retries)
+    assert requests.get.call_count == 3
+    assert fast_retries.call_count == 2
+
+
+def test_500_retried_until_max_then_raises_server_error(
+    mocker, fast_retries
+):
+    """Persistent 5xx raises VotesmartServerError after retries."""
+    mocker.patch.object(requests, "post")
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=_make_jwt(),
+        max_retries=1,
+    )
+    server_err = _mock_response(
+        500, {"statusCode": 500, "message": "Internal Server Error"}
+    )
+    mocker.patch.object(requests, "get", return_value=server_err)
+
+    with pytest.raises(VotesmartServerError) as exc_info:
+        api.api_call("v1/states")
+    assert exc_info.value.status_code == 500
+    assert "Internal Server Error" in str(exc_info.value)
+
+
+def test_500_was_already_handled_500_is_in_transient_set():
+    """5xx codes 502/503/504 are transient; pure 500 is NOT retried.
+
+    Some servers return 500 for permanent server bugs, so we keep it out
+    of the transient set to avoid masking those. Confirm the membership.
+    """
+    from votesmart.api import TRANSIENT_STATUS_CODES
+    assert 500 not in TRANSIENT_STATUS_CODES
+    assert 502 in TRANSIENT_STATUS_CODES
+    assert 503 in TRANSIENT_STATUS_CODES
+    assert 504 in TRANSIENT_STATUS_CODES
+    assert 429 in TRANSIENT_STATUS_CODES
+
+
+def test_500_not_retried_when_not_in_transient_set(mocker, fast_retries, authed_api):
+    """Confirm 500s raise immediately (no retry) — matches the previous
+    behavior for plain 500s."""
+    server_err = _mock_response(
+        500, {"statusCode": 500, "message": "Internal Server Error"}
+    )
+    mocker.patch.object(requests, "get", return_value=server_err)
+
+    with pytest.raises(VotesmartServerError) as exc_info:
+        authed_api.api_call("v1/states")
+    assert exc_info.value.status_code == 500
+    assert requests.get.call_count == 1
+    assert fast_retries.call_count == 0
+
+
+def test_400_not_retried_raises_client_error(mocker, fast_retries, authed_api):
+    """4xx other than 404/429 raises VotesmartClientError immediately."""
+    bad_request = _mock_response(
+        400, {"statusCode": 400, "message": "Bad year parameter"}
+    )
+    mocker.patch.object(requests, "get", return_value=bad_request)
+
+    with pytest.raises(VotesmartClientError) as exc_info:
+        authed_api.api_call("v1/elections/by-year-state", {"year": "abc"})
+    assert exc_info.value.status_code == 400
+    assert "Bad year parameter" in str(exc_info.value)
+    assert requests.get.call_count == 1
+
+
+def test_403_not_retried_raises_client_error(mocker, fast_retries, authed_api):
+    forbidden = _mock_response(403, text="Forbidden")
+    mocker.patch.object(requests, "get", return_value=forbidden)
+
+    with pytest.raises(VotesmartClientError) as exc_info:
+        authed_api.api_call("v1/admin/secret-endpoint")
+    assert exc_info.value.status_code == 403
+
+
+def test_max_retries_zero_disables_retry(mocker, fast_retries):
+    """max_retries=0 means: one attempt, no retries."""
+    mocker.patch.object(requests, "post")
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=_make_jwt(),
+        max_retries=0,
+    )
+    rate_limited = _mock_response(429)
+    mocker.patch.object(requests, "get", return_value=rate_limited)
+
+    with pytest.raises(VotesmartRateLimitError):
+        api.api_call("v1/candidatebios/123/detail")
+    assert requests.get.call_count == 1
+    assert fast_retries.call_count == 0
+
+
+# ---------------------------------------------------------------------
+# Retry-After honoring
+# ---------------------------------------------------------------------
+
+
+def test_retry_after_seconds_honored(mocker, fast_retries, authed_api):
+    """Numeric Retry-After header is used as the sleep duration."""
+    rate_limited = _mock_response(429, headers={"Retry-After": "7"})
+    success = _mock_response(200, {"ok": True})
+    mocker.patch.object(requests, "get", side_effect=[rate_limited, success])
+
+    authed_api.api_call("v1/states")
+    fast_retries.assert_called_once_with(7.0)
+
+
+def test_retry_after_http_date_honored(mocker, fast_retries, authed_api):
+    """HTTP-date Retry-After header is parsed correctly."""
+    future = datetime.now(timezone.utc) + timedelta(seconds=12)
+    rate_limited = _mock_response(
+        429,
+        headers={"Retry-After": email.utils.format_datetime(future)},
+    )
+    success = _mock_response(200, {"ok": True})
+    mocker.patch.object(requests, "get", side_effect=[rate_limited, success])
+
+    authed_api.api_call("v1/states")
+    fast_retries.assert_called_once()
+    delay = fast_retries.call_args[0][0]
+    # Should be close to 12 seconds, allowing for clock drift between the
+    # test fixture's `now` and the api module's `now`.
+    assert 9 < delay <= 12
+
+
+def test_retry_after_capped_at_retry_after_max(mocker, fast_retries):
+    """An absurd server-supplied Retry-After is capped at retry_after_max."""
+    mocker.patch.object(requests, "post")
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=_make_jwt(),
+        retry_after_max=30.0,
+    )
+    rate_limited = _mock_response(429, headers={"Retry-After": "999999"})
+    success = _mock_response(200, {"ok": True})
+    mocker.patch.object(requests, "get", side_effect=[rate_limited, success])
+
+    api.api_call("v1/states")
+    fast_retries.assert_called_once_with(30.0)
+
+
+def test_retry_after_unparseable_falls_back_to_backoff(
+    mocker, fast_retries, authed_api
+):
+    """Garbage Retry-After header falls back to exponential backoff."""
+    rate_limited = _mock_response(429, headers={"Retry-After": "garbage"})
+    success = _mock_response(200, {"ok": True})
+    mocker.patch.object(requests, "get", side_effect=[rate_limited, success])
+
+    authed_api.api_call("v1/states")
+    delay = fast_retries.call_args[0][0]
+    # Initial backoff is 1.0; jitter is ±50% by default; so delay ∈ [0.5, 1.5]
+    assert 0.5 <= delay <= 1.5
+
+
+# ---------------------------------------------------------------------
+# Exponential backoff
+# ---------------------------------------------------------------------
+
+
+def test_backoff_doubles_each_retry_without_jitter(mocker):
+    """With jitter disabled, backoff should double on each retry."""
+    mocker.patch.object(requests, "post")
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=_make_jwt(),
+        max_retries=3,
+        retry_initial_backoff=1.0,
+        retry_max_backoff=60.0,
+        retry_backoff_jitter=0.0,
+    )
+    sleep = mocker.patch("votesmart.api.time.sleep")
+    rate_limited = _mock_response(429)  # no Retry-After header
+    mocker.patch.object(requests, "get", return_value=rate_limited)
+
+    with pytest.raises(VotesmartRateLimitError):
+        api.api_call("v1/candidatebios/123/detail")
+
+    delays = [c[0][0] for c in sleep.call_args_list]
+    assert delays == [1.0, 2.0, 4.0]
+
+
+def test_backoff_capped_at_retry_max_backoff(mocker):
+    """Backoff plateaus at retry_max_backoff."""
+    mocker.patch.object(requests, "post")
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=_make_jwt(),
+        max_retries=5,
+        retry_initial_backoff=10.0,
+        retry_max_backoff=20.0,
+        retry_backoff_jitter=0.0,
+    )
+    sleep = mocker.patch("votesmart.api.time.sleep")
+    rate_limited = _mock_response(429)
+    mocker.patch.object(requests, "get", return_value=rate_limited)
+
+    with pytest.raises(VotesmartRateLimitError):
+        api.api_call("v1/candidatebios/123/detail")
+
+    delays = [c[0][0] for c in sleep.call_args_list]
+    # 10, 20 (capped), 20, 20, 20
+    assert delays == [10.0, 20.0, 20.0, 20.0, 20.0]
+
+
+def test_jitter_applied_to_backoff(mocker, authed_api):
+    """With jitter > 0, sleep durations land in [base*(1-j), base*(1+j)]."""
+    sleep = mocker.patch("votesmart.api.time.sleep")
+    rate_limited = _mock_response(429)
+    success = _mock_response(200, {"ok": True})
+    mocker.patch.object(requests, "get", side_effect=[rate_limited, success])
+
+    authed_api.api_call("v1/states")
+    delay = sleep.call_args[0][0]
+    # default initial_backoff=1.0, jitter=0.5 → [0.5, 1.5]
+    assert 0.5 <= delay <= 1.5
+
+
+# ---------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------
+
+
+def test_custom_rate_limiter_invoked_per_attempt(mocker, fast_retries):
+    """A custom rate_limiter callable is invoked before every request."""
+    limiter = mock.Mock()
+    mocker.patch.object(requests, "post")
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=_make_jwt(),
+        rate_limiter=limiter,
+        max_retries=2,
+    )
+    rate_limited = _mock_response(429)
+    success = _mock_response(200, {"ok": True})
+    mocker.patch.object(
+        requests, "get", side_effect=[rate_limited, rate_limited, success]
+    )
+
+    api.api_call("v1/states")
+    assert limiter.call_count == 3  # invoked before each of 3 attempts
+
+
+def test_custom_rate_limiter_takes_precedence_over_rate_limit(
+    mocker, fast_retries
+):
+    """When both rate_limiter and rate_limit are set, the callable wins."""
+    limiter = mock.Mock()
+    mocker.patch.object(requests, "post")
+    api = VoteSmartAPI(
+        email="test@test.com",
+        password="password",
+        access_token=_make_jwt(),
+        rate_limit=10,
+        rate_limiter=limiter,
+    )
+    success = _mock_response(200, {"ok": True})
+    mocker.patch.object(requests, "get", return_value=success)
+
+    api.api_call("v1/states")
+    limiter.assert_called_once()
+
+
+def test_builtin_rate_limit_still_works(mocker):
+    """The pre-existing rate_limit=N behavior is preserved when no
+    rate_limiter callable is given."""
+    mocker.patch.object(requests, "post")
+    # Pin _last_request_time so the first call also waits the full interval.
+    fake_now = [1000.0]
+
+    def fake_time():
+        return fake_now[0]
+
+    def fake_sleep(d):
+        fake_now[0] += d
+
+    mocker.patch("votesmart.api.time.time", side_effect=fake_time)
+    mocker.patch("votesmart.api.time.sleep", side_effect=fake_sleep)
 
     api = VoteSmartAPI(
         email="test@test.com",
         password="password",
-        access_token=token,
+        access_token=_make_jwt(),
+        rate_limit=2,  # 2 req/sec → 0.5s min interval
     )
-    with pytest.raises(VotesmartApiError, match="Internal Server Error"):
-        api.api_call('v1/states')
+    api._last_request_time = fake_now[0]  # simulate prior request just now
+
+    success = _mock_response(200, {"ok": True})
+    mocker.patch.object(requests, "get", return_value=success)
+
+    api.api_call("v1/states")
+    # min_interval is 0.5s; elapsed since _last_request_time is 0; expect sleep≈0.5
+    api.api_call("v1/states")  # second call
+    # We can't easily assert exact sleep without more bookkeeping; just confirm
+    # the call happened.
+    assert requests.get.call_count == 2
 
 
-def test_api_call_raises_on_500_without_json(mocker):
-    """500 with non-JSON body should include status code in error."""
-    token = _make_jwt()
-    mocker.patch.object(requests, 'post')
+# ---------------------------------------------------------------------
+# Exception introspection
+# ---------------------------------------------------------------------
 
-    error_response = mock.Mock()
-    error_response.status_code = 500
-    error_response.json.side_effect = ValueError("No JSON")
-    error_response.text = "<html>Internal Server Error</html>"
-    mocker.patch.object(requests, 'get', return_value=error_response)
 
-    api = VoteSmartAPI(
-        email="test@test.com",
-        password="password",
-        access_token=token,
-    )
-    with pytest.raises(VotesmartApiError, match="HTTP 500"):
-        api.api_call('v1/states')
+def test_exceptions_carry_status_code(mocker, fast_retries, authed_api):
+    """All HTTP-derived exceptions expose status_code + response_body."""
+    body = {"statusCode": 400, "message": "Bad query"}
+    bad = _mock_response(400, body)
+    mocker.patch.object(requests, "get", return_value=bad)
+
+    with pytest.raises(VotesmartClientError) as exc_info:
+        authed_api.api_call("v1/elections")
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.response_body == body
+
+
+def test_exception_str_includes_http_code():
+    """Exceptions without HTTP in their message get the code appended."""
+    exc = VotesmartRateLimitError("Slow down", status_code=429)
+    assert "HTTP 429" in str(exc)
+
+
+def test_exception_str_does_not_double_include_http():
+    """If the message already mentions HTTP, no duplication."""
+    exc = VotesmartApiError("API error (HTTP 500): boom", status_code=500)
+    # Just one occurrence
+    assert str(exc).count("HTTP 500") == 1
+
+
+def test_exception_hierarchy_is_subclassable():
+    """All new typed exceptions inherit from VotesmartApiError so existing
+    `except VotesmartApiError` catches still work."""
+    assert issubclass(VotesmartRateLimitError, VotesmartApiError)
+    assert issubclass(VotesmartServerError, VotesmartApiError)
+    assert issubclass(VotesmartClientError, VotesmartApiError)
+    assert issubclass(VotesmartNotFoundError, VotesmartApiError)
+
+
+# ---------------------------------------------------------------------
+# Misc — legacy behaviors that still need to hold
+# ---------------------------------------------------------------------
 
 
 def test_auth_failure_raises(mocker):
     """Failed auth should raise VotesmartApiError."""
-    auth_response = mock.Mock()
-    auth_response.status_code = 401
-    auth_response.text = "Unauthorized"
-    mocker.patch.object(requests, 'post', return_value=auth_response)
+    auth_response = _mock_response(401, text="Unauthorized")
+    mocker.patch.object(requests, "post", return_value=auth_response)
 
     with pytest.raises(VotesmartApiError):
         VoteSmartAPI(email="test@test.com", password="wrong")
@@ -265,14 +640,38 @@ def test_auth_failure_raises(mocker):
 
 def test_method_accessor_caching(mocker):
     """Method accessors should return the same instance on repeated access."""
-    token = _make_jwt()
-    mocker.patch.object(requests, 'post')
-
+    mocker.patch.object(requests, "post")
     api = VoteSmartAPI(
         email="test@test.com",
         password="password",
-        access_token=token,
+        access_token=_make_jwt(),
     )
     assert api.Candidates is api.Candidates
     assert api.Election is api.Election
     assert api.Rating is api.Rating
+
+
+def test_2xx_with_error_envelope_still_raises(mocker, authed_api):
+    """An error body smuggled inside a 200 response should still raise
+    (legacy parse_api_response behavior)."""
+    response = _mock_response(
+        200, {"statusCode": 400, "message": "actually bad"}
+    )
+    mocker.patch.object(requests, "get", return_value=response)
+
+    with pytest.raises(VotesmartApiError) as exc_info:
+        authed_api.api_call("v1/something")
+    assert "actually bad" in str(exc_info.value)
+    assert exc_info.value.status_code == 400
+
+
+def test_2xx_with_legacy_error_envelope_still_raises(mocker, authed_api):
+    """The legacy {error: {errorMessage}} envelope inside a 200 still raises."""
+    response = _mock_response(
+        200, {"error": {"errorMessage": "legacy error msg"}}
+    )
+    mocker.patch.object(requests, "get", return_value=response)
+
+    with pytest.raises(VotesmartApiError) as exc_info:
+        authed_api.api_call("v1/something")
+    assert "legacy error msg" in str(exc_info.value)

--- a/votesmart/api.py
+++ b/votesmart/api.py
@@ -1,19 +1,39 @@
 import base64
 import json
+import logging
+import random
 import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 
 import requests
 
 from .methods.utils import parse_api_response
-from .exceptions import VotesmartApiError, VotesmartNotFoundError
+from .exceptions import (
+    VotesmartApiError,
+    VotesmartClientError,
+    VotesmartNotFoundError,
+    VotesmartRateLimitError,
+    VotesmartServerError,
+)
 from . import methods
+
+
+logger = logging.getLogger(__name__)
+
+
+# HTTP status codes that are worth retrying. 429 is the primary motivator
+# (Vote Smart rate-limits aggressively); the 5xx set covers upstream
+# blips that typically resolve on a second attempt. 4xx codes other than
+# 429 are caller-side problems that retrying won't fix.
+TRANSIENT_STATUS_CODES = frozenset({429, 502, 503, 504})
 
 
 class VoteSmartAPI:
     """Client for the Vote Smart REST API 2.0.
 
     Authentication uses email/password to obtain a JWT access token from
-    the public auth endpoint.  Callers may pass in a cached token to avoid
+    the public auth endpoint. Callers may pass in a cached token to avoid
     re-authenticating on every instantiation.
 
     Args:
@@ -21,18 +41,49 @@ class VoteSmartAPI:
         password: Account password for Vote Smart API.
         access_token: Optional cached JWT token string.
         token_validity_period: Minimum remaining seconds before the token
-            is considered expired and a new one is requested.  Defaults to
-            3600 (1 hour).
-        rate_limit: Maximum requests per second.  If set, the client will
-            sleep between requests to stay under this limit.  Defaults to
-            None (no limiting).
+            is considered expired and a new one is requested. Defaults
+            to 3600 (1 hour).
+        rate_limit: Maximum requests per second for the built-in
+            in-process limiter. Ignored if ``rate_limiter`` is supplied.
+            Defaults to None (no in-process limiting).
+        rate_limiter: Optional callable ``f() -> None`` that blocks until
+            the next request is allowed. Takes precedence over
+            ``rate_limit``. Use this to plug in a distributed limiter
+            (e.g. Redis-backed token bucket) shared across processes.
+        max_retries: Number of retries to attempt on transient HTTP
+            errors (429, 502, 503, 504). Defaults to 5. Set to 0 to
+            disable.
+        retry_initial_backoff: Base delay (seconds) for the first retry
+            when no Retry-After header is present. Doubles on each
+            subsequent retry, capped at ``retry_max_backoff``. Defaults
+            to 1.0.
+        retry_max_backoff: Upper bound (seconds) on the computed
+            exponential backoff. Defaults to 60.0.
+        retry_backoff_jitter: Multiplicative jitter applied to backoff
+            delays, in the range ``[1 - jitter, 1 + jitter]``. Defaults
+            to 0.5 (i.e. ±50%). Set to 0.0 to disable.
+        retry_after_max: Upper bound (seconds) on a server-supplied
+            Retry-After value. Defends against absurd or hostile values.
+            Defaults to 300.0 (5 minutes).
     """
 
     AUTH_URL = "https://app.votesmart-api.org/auth/login"
     BASE_URL = "https://app.votesmart-api.org"
 
-    def __init__(self, email=None, password=None, access_token=None,
-                 token_validity_period=3600, rate_limit=None):
+    def __init__(
+        self,
+        email=None,
+        password=None,
+        access_token=None,
+        token_validity_period=3600,
+        rate_limit=None,
+        rate_limiter=None,
+        max_retries=5,
+        retry_initial_backoff=1.0,
+        retry_max_backoff=60.0,
+        retry_backoff_jitter=0.5,
+        retry_after_max=300.0,
+    ):
         if not email or not password:
             raise ValueError("Vote Smart API email and password are required")
 
@@ -42,8 +93,18 @@ class VoteSmartAPI:
         self._access_token = access_token
         self._token_changed = False
         self._method_cache = {}
-        self._rate_limit = rate_limit  # max requests per second, or None
+
+        # Rate limiting
+        self._rate_limit = rate_limit
+        self._rate_limiter = rate_limiter
         self._last_request_time = 0
+
+        # Retry-with-backoff config
+        self._max_retries = max_retries
+        self._retry_initial_backoff = retry_initial_backoff
+        self._retry_max_backoff = retry_max_backoff
+        self._retry_backoff_jitter = retry_backoff_jitter
+        self._retry_after_max = retry_after_max
 
         # Validate or refresh the token
         if not self._is_token_valid():
@@ -55,7 +116,7 @@ class VoteSmartAPI:
 
     @property
     def access_token(self):
-        """Return the current access token.  If it was refreshed during
+        """Return the current access token. If it was refreshed during
         init or an API call, the caller should cache the new value."""
         return self._access_token
 
@@ -84,9 +145,8 @@ class VoteSmartAPI:
         )
         if response.status_code not in (200, 201):
             raise VotesmartApiError(
-                "Authentication failed (HTTP {}): {}".format(
-                    response.status_code, response.text
-                )
+                "Authentication failed: {}".format(response.text),
+                status_code=response.status_code,
             )
         data = response.json()
         token = data.get("accessToken") or data.get("access_token")
@@ -103,7 +163,6 @@ class VoteSmartAPI:
         parts = token.split(".")
         if len(parts) != 3:
             raise ValueError("Invalid JWT format")
-        # Add padding for base64
         payload_b64 = parts[1]
         padding = 4 - len(payload_b64) % 4
         if padding != 4:
@@ -118,6 +177,12 @@ class VoteSmartAPI:
     def api_call(self, endpoint, params=None):
         """Make an authenticated GET request to the Vote Smart API.
 
+        Retries transparently on transient errors (429, 502, 503, 504),
+        honoring the server's ``Retry-After`` header when present and
+        falling back to exponential backoff with jitter otherwise.
+        Permanent errors (400, 401-after-refresh, 403, etc.) raise the
+        appropriate typed exception immediately.
+
         Args:
             endpoint: API endpoint path (e.g. "v1/elections" or
                 "v1/candidates/by-election").
@@ -130,68 +195,255 @@ class VoteSmartAPI:
         if not self._is_token_valid():
             self._authenticate()
 
-        # Rate limiting: wait if needed to stay under the limit
+        url = "{}/{}".format(self.BASE_URL, endpoint.lstrip("/"))
+
+        backoff = self._retry_initial_backoff
+        last_response = None
+
+        for attempt in range(self._max_retries + 1):
+            # Respect the configured rate limit before EVERY attempt.
+            # Retry delays are additive on top of the local rate budget.
+            self._wait_for_rate_limit()
+
+            response = self._send_with_auth_refresh(url, params)
+            last_response = response
+
+            # 404 is never retried — it's either "no data" (a real,
+            # actionable result for list-shaped callers) or "wrong URL"
+            # (a caller bug). Both cases raise.
+            if response.status_code == 404:
+                self._raise_404(response, url)
+
+            if response.status_code in TRANSIENT_STATUS_CODES:
+                if attempt < self._max_retries:
+                    delay = self._compute_retry_delay(response, backoff)
+                    logger.info(
+                        "VoteSmart %s returned %d; sleeping %.2fs before retry "
+                        "(attempt %d/%d)",
+                        url,
+                        response.status_code,
+                        delay,
+                        attempt + 1,
+                        self._max_retries,
+                    )
+                    time.sleep(delay)
+                    backoff = min(backoff * 2, self._retry_max_backoff)
+                    continue
+                logger.warning(
+                    "VoteSmart %s returned %d; retries exhausted after %d attempts",
+                    url,
+                    response.status_code,
+                    self._max_retries + 1,
+                )
+                # Fall through to raise
+
+            if response.status_code >= 400:
+                self._raise_for_status(response, url)  # raises
+
+            # 2xx — parse and return. parse_api_response handles the case
+            # where an error envelope is smuggled inside a 2xx response.
+            try:
+                data = response.json()
+            except ValueError:
+                raise VotesmartApiError(
+                    "Invalid JSON response from API",
+                    status_code=response.status_code,
+                )
+            return parse_api_response(data)
+
+        # Defensive: the for-else equivalent. We should not reach here in
+        # practice — either we returned successfully or one of the raise
+        # paths above fired. If we do, treat the last response as a
+        # failure so we don't silently return None.
+        if last_response is not None:
+            self._raise_for_status(last_response, url)
+        raise VotesmartApiError("Retry loop completed without a response")
+
+    # ------------------------------------------------------------------
+    # Retry / rate-limit helpers
+    # ------------------------------------------------------------------
+
+    def _send_with_auth_refresh(self, url, params):
+        """Send a single request. On 401, re-authenticate and retry once
+        with the new token. Returns the final response (which may itself
+        still be a 401 if re-auth didn't fix it; the caller decides what
+        to do with that)."""
+        headers = {"Authorization": "Bearer {}".format(self._access_token)}
+        self._last_request_time = time.time()
+        response = requests.get(url, params=params or {}, headers=headers)
+
+        if response.status_code == 401:
+            self._authenticate()
+            headers = {
+                "Authorization": "Bearer {}".format(self._access_token)
+            }
+            self._last_request_time = time.time()
+            response = requests.get(url, params=params or {}, headers=headers)
+
+        return response
+
+    def _wait_for_rate_limit(self):
+        """Block until the configured limiter allows the next request.
+
+        If a custom ``rate_limiter`` callable was supplied, it takes
+        precedence. Otherwise the built-in in-process limiter sleeps to
+        keep us under ``rate_limit`` requests per second. No limiter
+        configured means no waiting.
+        """
+        if self._rate_limiter is not None:
+            self._rate_limiter()
+            return
         if self._rate_limit:
             min_interval = 1.0 / self._rate_limit
             elapsed = time.time() - self._last_request_time
             if elapsed < min_interval:
                 time.sleep(min_interval - elapsed)
 
-        url = "{}/{}".format(self.BASE_URL, endpoint.lstrip("/"))
-        headers = {"Authorization": "Bearer {}".format(self._access_token)}
+    def _compute_retry_delay(self, response, default_backoff):
+        """Return the delay (seconds) before the next retry attempt.
 
-        self._last_request_time = time.time()
-        response = requests.get(url, params=params or {}, headers=headers)
-
-        if response.status_code == 401:
-            # Token may have expired mid-session — retry once
-            self._authenticate()
-            headers = {"Authorization": "Bearer {}".format(self._access_token)}
-            response = requests.get(url, params=params or {}, headers=headers)
-
-        if response.status_code == 404:
-            try:
-                body = response.json()
-            except ValueError:
-                body = None
-            # Route exists but VS has no data for this query. Body shape:
-            #   {"message": "Not Found", "statusCode": 404}
-            # List-shaped callers (paginated_api_call) catch this and return []
-            # so iteration can proceed; object-shaped callers let it propagate
-            # so they can tell when they passed a bad ID.
-            if (
-                isinstance(body, dict)
-                and body.get("message") == "Not Found"
-                and "error" not in body
-            ):
-                raise VotesmartNotFoundError(
-                    "Resource not found: {} (HTTP 404)".format(url)
-                )
-            # Anything else — Express's "Cannot GET /v1/..." for a wrong path,
-            # an HTML page from infrastructure, an empty body, an unexpected
-            # shape — is a caller bug or upstream issue. Surface it.
-            raise VotesmartApiError(
-                "Endpoint not found: {} (HTTP 404)".format(url)
+        Prefers a server-supplied ``Retry-After`` header (capped at
+        ``retry_after_max``). Falls back to ``default_backoff`` with
+        multiplicative jitter applied.
+        """
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            parsed = self._parse_retry_after(retry_after)
+            if parsed is not None:
+                return min(parsed, self._retry_after_max)
+        if self._retry_backoff_jitter:
+            jitter_factor = 1.0 + random.uniform(
+                -self._retry_backoff_jitter, self._retry_backoff_jitter
             )
+            return max(0.0, default_backoff * jitter_factor)
+        return default_backoff
 
-        # Check for HTTP errors before attempting JSON parse
-        if response.status_code >= 400:
-            try:
-                data = response.json()
-            except ValueError:
-                raise VotesmartApiError(
-                    "API error (HTTP {}): {}".format(
-                        response.status_code, response.text[:500]
-                    )
-                )
-            return parse_api_response(data)
+    @staticmethod
+    def _parse_retry_after(value):
+        """Parse a Retry-After header value.
 
+        Per RFC 7231 §7.1.3 it's either:
+          - delta-seconds (a non-negative integer), or
+          - HTTP-date (RFC 7231 §7.1.1.1).
+
+        Returns the delay in seconds, or ``None`` if unparseable.
+        """
+        value = value.strip()
         try:
-            data = response.json()
+            return max(0.0, float(value))
         except ValueError:
-            raise VotesmartApiError("Invalid JSON response from API")
+            pass
+        try:
+            dt = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+        if dt is None:
+            return None
+        now = datetime.now(timezone.utc) if dt.tzinfo else datetime.now()
+        return max(0.0, (dt - now).total_seconds())
 
-        return parse_api_response(data)
+    # ------------------------------------------------------------------
+    # Error-mapping helpers
+    # ------------------------------------------------------------------
+
+    def _raise_404(self, response, url):
+        """Distinguish 'no data' 404s from malformed-URL 404s.
+
+        - Body shape ``{"message": "Not Found", "statusCode": 404}`` →
+          ``VotesmartNotFoundError``. The route exists but VS has no
+          data for the query. List-shaped callers catch this and return
+          an empty list.
+        - Any other 404 (Express's "Cannot GET /v1/...", an HTML page
+          from infrastructure, empty body, unrecognized shape) →
+          ``VotesmartApiError``. Surfaces caller bugs and upstream
+          oddities instead of silently treating them as "no data."
+        """
+        try:
+            body = response.json()
+        except ValueError:
+            body = None
+        if (
+            isinstance(body, dict)
+            and body.get("message") == "Not Found"
+            and "error" not in body
+        ):
+            raise VotesmartNotFoundError(
+                "Resource not found: {}".format(url),
+                status_code=404,
+                response_body=body,
+            )
+        raise VotesmartApiError(
+            "Endpoint not found: {}".format(url),
+            status_code=404,
+            response_body=body,
+        )
+
+    def _raise_for_status(self, response, url):
+        """Map a >= 400 response to a typed exception and raise.
+
+        - 429 → ``VotesmartRateLimitError``
+        - 5xx → ``VotesmartServerError``
+        - other 4xx (except 404, handled separately) →
+          ``VotesmartClientError``
+        - anything else (shouldn't happen given the caller's 2xx guard) →
+          ``VotesmartApiError``
+
+        All carry ``status_code`` and ``response_body`` for callers that
+        want to introspect.
+        """
+        code = response.status_code
+        try:
+            body = response.json()
+        except ValueError:
+            body = None
+        message = self._extract_error_message(body) or self._fallback_text(response)
+
+        if code == 429:
+            raise VotesmartRateLimitError(
+                "Rate limited by VoteSmart: {}".format(message),
+                status_code=code,
+                response_body=body,
+            )
+        if 500 <= code < 600:
+            raise VotesmartServerError(
+                "VoteSmart server error: {}".format(message),
+                status_code=code,
+                response_body=body,
+            )
+        if 400 <= code < 500:
+            raise VotesmartClientError(
+                "VoteSmart client error: {}".format(message),
+                status_code=code,
+                response_body=body,
+            )
+        raise VotesmartApiError(
+            "Unexpected response status: {}".format(message),
+            status_code=code,
+            response_body=body,
+        )
+
+    @staticmethod
+    def _extract_error_message(body):
+        """Pull a human-readable message from a parsed JSON error body."""
+        if not isinstance(body, dict):
+            return None
+        message = body.get("message")
+        if message:
+            return message
+        err = body.get("error")
+        if isinstance(err, dict):
+            return err.get("errorMessage")
+        if isinstance(err, str):
+            return err
+        return None
+
+    @staticmethod
+    def _fallback_text(response):
+        """Use the raw response text (truncated) when no JSON body."""
+        text = (response.text or "").strip()
+        if text:
+            return text[:500]
+        return "no response body"
 
     # ------------------------------------------------------------------
     # Method accessors (cached)

--- a/votesmart/exceptions.py
+++ b/votesmart/exceptions.py
@@ -1,5 +1,26 @@
 class VotesmartApiError(Exception):
-    """Exception for Votesmart API errors"""
+    """Base class for all Vote Smart API errors.
+
+    Carries ``status_code`` (the HTTP status from the API, when known) and
+    ``response_body`` (the parsed JSON response body, when available). Both
+    are ``None`` if the error didn't originate from an HTTP response (e.g.,
+    a malformed JWT, a missing auth token).
+
+    The string form of the exception includes ``(HTTP <code>)`` when a
+    status code is set and the message doesn't already mention HTTP — so
+    callers that just log ``str(exc)`` get a self-diagnosing line.
+    """
+
+    def __init__(self, message="", status_code=None, response_body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+    def __str__(self):
+        message = super().__str__()
+        if self.status_code is not None and "HTTP" not in message:
+            return "{} (HTTP {})".format(message, self.status_code)
+        return message
 
 
 class VotesmartNotFoundError(VotesmartApiError):
@@ -11,3 +32,27 @@ class VotesmartNotFoundError(VotesmartApiError):
     list-shaped endpoints can return an empty list while object-shaped
     endpoints still surface a missing resource to the caller.
     """
+
+
+class VotesmartRateLimitError(VotesmartApiError):
+    """Raised when the API returns 429 Too Many Requests and the configured
+    retry budget is exhausted.
+
+    Callers that want to handle rate-limiting specifically (back off
+    further at the application layer, requeue the work, etc.) should
+    ``except VotesmartRateLimitError`` before the broader
+    ``VotesmartApiError``.
+    """
+
+
+class VotesmartServerError(VotesmartApiError):
+    """Raised on a 5xx response after the configured retry budget is
+    exhausted. Indicates a Vote Smart upstream problem rather than a
+    caller bug."""
+
+
+class VotesmartClientError(VotesmartApiError):
+    """Raised on a 4xx response that isn't 404 (no-data) or 429
+    (rate-limit). Typically a 400 (bad request), 401 (auth refresh
+    didn't fix it), or 403 (forbidden) — i.e., a caller-side problem
+    that retrying won't solve."""

--- a/votesmart/methods/utils.py
+++ b/votesmart/methods/utils.py
@@ -2,18 +2,31 @@ from ..exceptions import VotesmartApiError
 
 
 def parse_api_response(response):
-    """Parse an API response, raising on errors.
+    """Parse an API response, raising on error envelopes.
 
-    The new REST API 2.0 returns errors as {"message": "...", "statusCode": N}
-    while the legacy API used {"error": {"errorMessage": "..."}}.
+    Detects API errors that come back wrapped in a 2xx HTTP response. The
+    REST API 2.0 uses ``{"message": "...", "statusCode": N}`` for errors
+    while the legacy API used ``{"error": {"errorMessage": "..."}}`` — we
+    handle both for backward compatibility.
+
+    HTTP-level errors (4xx, 5xx) are mapped to the typed exceptions in
+    ``VoteSmartAPI._raise_for_status`` *before* this function is called,
+    so the ``statusCode`` branch here only fires when an error body is
+    smuggled inside a 2xx response.
     """
-    # New API error format
     if isinstance(response, dict):
-        if response.get("statusCode") and response["statusCode"] >= 400:
+        body_status = response.get("statusCode")
+        if body_status and body_status >= 400:
             raise VotesmartApiError(
-                response.get("message", "Unknown API error")
+                response.get("message", "Unknown API error"),
+                status_code=body_status,
+                response_body=response,
             )
-        # Legacy error format (kept for compatibility)
         if response.get("error"):
-            raise VotesmartApiError(response["error"]["errorMessage"])
+            err = response["error"]
+            message = err.get("errorMessage") if isinstance(err, dict) else str(err)
+            raise VotesmartApiError(
+                message or "Unknown API error",
+                response_body=response,
+            )
     return response


### PR DESCRIPTION
### Parent ticket

[nj-cms #8558](https://github.com/NationalJournal/nj-cms/issues/8558) — what started as an orphan-candidate cleanup turned into "99% of the 'failed to get bio data' Sentry events are 429s, not real orphans." Fixing py-votesmart is now the gating work.

### Summary

- `api_call` now transparently retries transient HTTP errors (429, 502, 503, 504). Honors the server's `Retry-After` header (integer-seconds + RFC 7231 HTTP-date) and falls back to exponential backoff with multiplicative jitter otherwise. Configurable via constructor params (`max_retries=5`, `retry_initial_backoff=1.0`, `retry_max_backoff=60.0`, `retry_backoff_jitter=0.5`, `retry_after_max=300.0`).
- New typed exception subclasses of `VotesmartApiError`:
  - `VotesmartRateLimitError` — 429 after retries exhausted
  - `VotesmartServerError` — 5xx after retries exhausted
  - `VotesmartClientError` — non-404, non-429 4xx (400/401-after-refresh/403/etc.)

  All inherit `VotesmartApiError`, so `except VotesmartApiError` catches still work. They carry `status_code` and `response_body` attributes, and `str(exc)` now includes `(HTTP <code>)` automatically — callers that just log `str(exc)` get self-diagnosing lines.
- New pluggable `rate_limiter` callable constructor param (`f() -> None` that blocks until allowed). Takes precedence over the existing `rate_limit=N` in-process limiter. Lets callers plug in a distributed limiter if they need cross-process coordination later.
- No new external dependencies.
- Version bump to 2.1.0.

The retry layer is the main fix: pre-2.1.0, a single 429 became a permanent "Failed to get bio data" warning in the caller's logs. Now 429s are absorbed silently (honoring Retry-After), only escalating to a typed exception once the retry budget is exhausted.

### Testing

- [ ] `make test` — 180/180 pass (38 in `tests/test_api.py`, 142 across method tests)
- [ ] Tag `v2.1.0` after merge so the nj-cms followup PR can pin against it

### Followup

nj-cms PR will bump the requirements pin, surface the new HTTP-status-in-log information in `votesmart_utils.py` (and the silent-swallow wrappers in `votesmart_helper.py`), and stop falsely marking rate-limited candidates as "tried" so they retry on the next sync cycle.