### PR TITLE
nj-cms #8611 Fix IndexError in _parse_start_year on whitespace-only spans

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 py-votesmart changelog
 ==========================
 
+2.1.1
+-----
+    * Fix ``IndexError`` in ``_parse_start_year()`` (candidate bio date
+      parsing) when a bio entry's ``span`` is truthy but
+      whitespace/comma-only (e.g. ``" "`` or ``","``). Such spans now
+      resolve to a start year of ``0`` instead of raising, matching the
+      existing fallback behavior of ``_parse_end_year()``.
+
 2.1.0
 -----
     * Rate-limiting / retry overhaul. ``api_call`` now transparently

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_requires(path=REQUIRE_PATH):
 
 setup(
     name="py-votesmart",
-    version="2.1.0",
+    version="2.1.1",
     description="Python library for the Vote Smart REST API 2.0",
     author="Nathan Danielsen <nathan.danielsen@gmail.com>",
     author_email="nathan.danielsen@gmail.com",

--- a/tests/test_methods/test_candidatebio.py
+++ b/tests/test_methods/test_candidatebio.py
@@ -2,6 +2,7 @@ from unittest import mock
 from votesmart.methods.candidatebio import (
     CandidateBio, Bio, AddlBio,
     _build_full_text, _ensure_full_text, _sort_key,
+    _parse_start_year, _parse_end_year,
 )
 
 
@@ -90,6 +91,65 @@ class TestBuildFullTextEducation:
         assert '3.8' not in result
 
 
+# --- _parse_start_year / _parse_end_year tests ---
+
+class TestParseStartYear:
+
+    def test_single_year(self):
+        assert _parse_start_year('1975') == 1975
+
+    def test_range(self):
+        assert _parse_start_year('2013-2015') == 2013
+
+    def test_present(self):
+        assert _parse_start_year('2021-present') == 2021
+
+    def test_comma_separated(self):
+        assert _parse_start_year('2022, 2026') == 2022
+
+    def test_empty_span(self):
+        assert _parse_start_year('') == 0
+
+    def test_none_span(self):
+        assert _parse_start_year(None) == 0
+
+    def test_present_only(self):
+        """A bare 'present' has no leading year and isn't crashable, per ticket nj-cms-8611"""
+        assert _parse_start_year('present') == 0
+
+    def test_whitespace_only_span(self):
+        """Regression for nj-cms-8611: whitespace-only span crashed with IndexError"""
+        assert _parse_start_year(' ') == 0
+
+    def test_comma_only_span(self):
+        """Regression for nj-cms-8611: comma-only span crashed with IndexError"""
+        assert _parse_start_year(',') == 0
+
+
+class TestParseEndYear:
+
+    def test_single_year(self):
+        assert _parse_end_year('1975') == 1975
+
+    def test_range(self):
+        assert _parse_end_year('2013-2015') == 2015
+
+    def test_present(self):
+        assert _parse_end_year('2021-present') == 9999
+
+    def test_comma_separated(self):
+        assert _parse_end_year('2022, 2026') == 2026
+
+    def test_empty_span(self):
+        assert _parse_end_year('') == 0
+
+    def test_whitespace_only_span(self):
+        assert _parse_end_year(' ') == 0
+
+    def test_comma_only_span(self):
+        assert _parse_end_year(',') == 0
+
+
 # --- _sort_key tests ---
 
 class TestSortKey:
@@ -170,6 +230,16 @@ class TestSortKey:
     def test_missing_span_key(self):
         entries = [
             {'fullText': 'no span key'},
+            {'span': '2020', 'fullText': 'has span'},
+        ]
+        sorted_entries = sorted(entries, key=_sort_key)
+        assert sorted_entries[0]['span'] == '2020'
+
+    def test_whitespace_only_span_does_not_crash(self):
+        """Regression for nj-cms-8611: a truthy but whitespace-only span crashed
+        _parse_start_year with IndexError during sorting."""
+        entries = [
+            {'span': ' ', 'fullText': 'blank span'},
             {'span': '2020', 'fullText': 'has span'},
         ]
         sorted_entries = sorted(entries, key=_sort_key)

--- a/votesmart/methods/candidatebio.py
+++ b/votesmart/methods/candidatebio.py
@@ -87,10 +87,12 @@ def _parse_start_year(span):
     if not span:
         return 0
     # Handle "2013-2015", "2022, 2026", "2021-present", "1975"
-    first_token = span.replace(',', ' ').split()[0]
+    parts = span.replace(',', ' ').split()
+    if not parts:
+        return 0
     try:
-        return int(first_token.split('-')[0])
-    except (ValueError, IndexError):
+        return int(parts[0].split('-')[0])
+    except ValueError:
         return 0
 
 


### PR DESCRIPTION
### Ticket #8611

## Summary
- `_parse_start_year()` in `votesmart/methods/candidatebio.py` indexed `[0]` into the result of
  `span.replace(',', ' ').split()` *outside* its try/except. A truthy but whitespace/comma-only span
  (e.g. `" "` or `","`) makes `split()` return `[]`, so the `[0]` raised an uncaught `IndexError`.
  `_parse_end_year()` avoids this by iterating with `for token in reversed(parts)` instead of indexing.
- Fix: compute the token list first, return `0` immediately if it's empty, then only try/except around
  the `int(...)` conversion.
- Root-cause for nj-cms#8611 — Sentry errors from `update_racetracker_election_data` hitting this
  IndexError while sorting candidate bio entries. The `"present"` span called out in that ticket's body
  was a red herring; it was already handled safely by the existing except clause.

## Test plan
- [x] Added `TestParseStartYear` / `TestParseEndYear` unit tests, including whitespace-only and
      comma-only span cases
- [x] Added a `_sort_key` regression test exercising the same crash path end-to-end
- [x] `pytest tests/test_methods/test_candidatebio.py -v` — all pass
- [x] `pytest tests/ --ignore=tests/test_live_api.py -q` — 197 passed


This will need a version bump in the nj-cms repo requirements.txt as well.